### PR TITLE
Revert "don't do surface fitting during tiltalign"

### DIFF
--- a/yet_another_imod_wrapper/batchruntomo_config/fiducials.adoc
+++ b/yet_another_imod_wrapper/batchruntomo_config/fiducials.adoc
@@ -27,7 +27,7 @@ comparam.eraser.ccderaser.PeakCriterion = 8.0
 comparam.eraser.ccderaser.DiffCriterion = 6.0
 
 comparam.align.tiltalign.TiltOption = 0
-comparam.align.tiltalign.SurfacesToAnalyze = 0
+comparam.align.tiltalign.SurfacesToAnalyze = 1
 comparam.align.tiltalign.RotOption = -1
 comparam.align.tiltalign.MagOption = 0
 comparam.align.tiltalign.BeamTiltOption = 2


### PR DESCRIPTION
Reverts teamtomo/yet-another-imod-wrapper#14

This option causes BRT to fail - not sure why...