### PR TITLE
fix docs deployment

### DIFF
--- a/.github/workflows/build-and-deploy-docs.yml
+++ b/.github/workflows/build-and-deploy-docs.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          # pip install -e .
+          pip install -e .
           pip install mkdocs mkdocs-material mkdocstrings[python]
 
       # Build the book


### PR DESCRIPTION
docs deployment now uses mkdocstrings to autogenerate some documentation, requiring the package be installed