### PR TITLE
change source of angle offset in align.log file

### DIFF
--- a/src/yet_another_imod_wrapper/utils/etomo.py
+++ b/src/yet_another_imod_wrapper/utils/etomo.py
@@ -109,7 +109,7 @@ def get_tilt_angle_offset(align_log_file: Path) -> Union[float, None]:
     """Get the total tilt angle offset from an align.log file."""
     with open(align_log_file, mode='r') as file:
         for line in file:
-            if 'Total tilt angle change =' in line:
+            if 'AngleOffset =' in line:
                 return float(line.strip().split('=')[-1])
     return None
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -59,7 +59,7 @@ def test_get_batchruntomo_command(tmp_path):
 def test_get_tilt_angle_offset(align_log_file):
     """Test getting tilt angle offset from align.log."""
     result = utils.etomo.get_tilt_angle_offset(align_log_file)
-    assert result == 10.02
+    assert result == 9.02
 
 
 def test_get_input_rotation_angle(align_log_file):


### PR DESCRIPTION
seems like the previously used source of the offset is incorrect and only accounts for part of the actual applied offset... it appears from Sjors' example data this is the correct source